### PR TITLE
Remove the_content() from writing section.

### DIFF
--- a/page-templates/teaching-resources.php
+++ b/page-templates/teaching-resources.php
@@ -105,14 +105,7 @@ $writing_cat = get_term_by( 'slug', 'writing', 'category', 'OBJECT' );
 
 				<article class="type-page page tr-content">
 
-				<?php while( have_posts() ) : the_post();
-				the_content();
-				?>
-				</article>
-
-			<?php endwhile;
-			wp_reset_query();
-			?>
+				
 				<ul>
 					<?php
 						$writing_query = new WP_Query('cat=' . $writing_cat->term_id );


### PR DESCRIPTION
For some reason, the page content was being called in the Writing section of the Teaching Resources template in addition to the top of the pate.